### PR TITLE
KICKコマンド コメントロジック修正

### DIFF
--- a/srcs/Server/Command/Kick.cpp
+++ b/srcs/Server/Command/Kick.cpp
@@ -16,7 +16,6 @@ void Server::handleKick(Client* client, const std::vector<std::string> &data)
 	// コメントがある場合
 	if (data.size() > 3)
 	{
-		comment = (data.size() > 3) ? data[3] : "";
 		// コメントにコロンが含まれているかチェックし、再構築
 		if (data[3][0] == ':')
 		{

--- a/srcs/Server/Command/Kick.cpp
+++ b/srcs/Server/Command/Kick.cpp
@@ -11,21 +11,26 @@ void Server::handleKick(Client* client, const std::vector<std::string> &data)
 
 	std::string channelName = data[1];
 	std::string targetNick = data[2];
-	std::string comment = (data.size() > 3) ? data[3] : "";
+	std::string comment;
 
-	// コメントにコロンが含まれているかチェックし、再構築
-	if (data.size() > 3 && data[3][0] == ':')
+	// コメントがある場合
+	if (data.size() > 3)
 	{
-		comment = data[3].substr(1);
-		for (size_t i = 4; i < data.size(); ++i)
-			comment += " " + data[i];
-	}
-	else
-	{
-		// コロンがない場合、プロトコル違反とみなし、エラーを返す
-		// この場合、ERR_NEEDMOREPARAMS (461) を返す
-		sendToClient(client->getFd(), getServerPrefix() + " 461 " + client->getNickname() + " KICK :Not enough parameters");
-		return;
+		comment = (data.size() > 3) ? data[3] : "";
+		// コメントにコロンが含まれているかチェックし、再構築
+		if (data[3][0] == ':')
+		{
+			comment = data[3].substr(1);
+			for (size_t i = 4; i < data.size(); ++i)
+				comment += " " + data[i];
+		}
+		else
+		{
+			// コロンがない場合、プロトコル違反とみなし、エラーを返す
+			// この場合、ERR_NEEDMOREPARAMS (461) を返す
+			sendToClient(client->getFd(), getServerPrefix() + " 461 " + client->getNickname() + " KICK :Not enough parameters");
+			return;
+		}
 	}
 
 	// チャンネルの存在チェック: ERR_NOSUCHCHANNEL (403)

--- a/srcs/Server/Command/Pass.cpp
+++ b/srcs/Server/Command/Pass.cpp
@@ -3,6 +3,13 @@
 //=== PASS ===
 void Server::handlePass(Client* client, const std::vector<std::string> &data)
 {
+	// パラメータのチェック: ERR_NEEDMOREPARAMS (461)
+	if (data.size() < 2)
+	{
+		sendToClient(client->getFd(), getServerPrefix() + " 461 " + client->getNickname() + " KICK :Not enough parameters");
+		return;
+	}
+
 	std::string password = data[1];
 	// password.erase(password.find_last_not_of(" \r\n\t") + 1);
 	// password.erase(0, password.find_first_not_of(" \r\n\t"));

--- a/srcs/Server/Command/Pass.cpp
+++ b/srcs/Server/Command/Pass.cpp
@@ -6,7 +6,7 @@ void Server::handlePass(Client* client, const std::vector<std::string> &data)
 	// パラメータのチェック: ERR_NEEDMOREPARAMS (461)
 	if (data.size() < 2)
 	{
-		sendToClient(client->getFd(), getServerPrefix() + " 461 " + client->getNickname() + " KICK :Not enough parameters");
+		sendToClient(client->getFd(), getServerPrefix() + " 461 " + client->getNickname() + " PASS :Not enough parameters");
 		return;
 	}
 


### PR DESCRIPTION
KICKコマンドにコメントがある場合のロジックを修正。
PASSコマンドにパラメーターチェックを追加。
現状だと、PASS単体でコマンド実行されたときにセグフォになってしまう。